### PR TITLE
Package/module info in doc results

### DIFF
--- a/src/lt/plugins/haskell.cljs
+++ b/src/lt/plugins/haskell.cljs
@@ -48,9 +48,12 @@
 (defn convert-doc-result [hoogle-doc]
   (if (nil? hoogle-doc)
     nil
+    (let [location (.-location hoogle-doc)
+          [_ doc-package doc-raw-module] (.exec #"http://hackage.haskell.org/packages/archive/(.+)/latest/doc/html/(.+).html" location)
+          doc-module (.replace doc-raw-module "-" ".")]
     {:name (.-self hoogle-doc)
-     :ns   [:a {:href (.-location hoogle-doc)} "hoogle"]
-     :doc  (.-docs hoogle-doc)}))
+     :ns   [:a {:href location} (str "Hoogle (" doc-package ": " doc-module ")")]
+     :doc  (.-docs hoogle-doc)})))
 
 
 (defn convert-results [results]


### PR DESCRIPTION
I started hacking up a Hoogle integration yesterday, but you seem to be a bit farther along than I...

This tiny PR improves the documentation slightly by including the package and module name in the retrieved doc.
