### PR TITLE
Compiling with style

### DIFF
--- a/haskell/LTHaskellClient.hs
+++ b/haskell/LTHaskellClient.hs
@@ -1,18 +1,15 @@
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-import           Control.Concurrent         (forkIO)
 import           Network                    (PortID (..), connectTo,
                                              withSocketsDo)
-import           Network.Socket             (send, socketToHandle)
 import           System.Directory           (getCurrentDirectory)
 import           System.Environment         (getArgs)
-import           System.IO                  (BufferMode (..), Handle,
-                                             IOMode (..), hClose, hFlush,
-                                             hGetContents, hGetLine, hPutStr,
-                                             hPutStrLn, hSetBuffering, stderr,
+import           System.IO                  (Handle,
+                                             hFlush,
+                                             hGetLine,
+                                             hPutStrLn, stderr,
                                              stdout)
-import           System.Process             (readProcess)
 
 import           Control.Applicative        ((<$>))
 
@@ -31,11 +28,11 @@ main :: IO ()
 main = withSocketsDo $ do
     [portStr, clientIdStr] <- getArgs
     let port = fromIntegral (read portStr :: Int)
-        clientId = (read clientIdStr :: Int)
+        clientId = read clientIdStr
     handle <- connectTo "localhost" (PortNumber port)
     cwd <- getCurrentDirectory
 
-    hPutStrLn stdout $ "Connected: " ++ cwd
+    putStrLn $ "Connected: " ++ cwd
     hFlush stdout
 
     sendResponse handle $ LTConnection "Haskell" "haskell" clientId cwd ["haskell.api.reformat", "haskell.api.syntax"]
@@ -45,8 +42,8 @@ main = withSocketsDo $ do
 processCommands :: Handle -> IO ()
 processCommands handle = do
   line <- hGetLine handle
-  case (parseCommand line) of
-    Left error -> hPutStrLn stderr ("error" ++ error)
+  case parseCommand line of
+    Left e -> hPutStrLn stderr ("Error processing command: " ++ e)
     Right ltCommand -> execCommand handle ltCommand
 
   processCommands handle


### PR DESCRIPTION
This compiles against `stylish-haskell` directly, instead of shelling out. One less environmental dependency...

To celebrate, this also clears out all syntax/linter warnings from the haskell client.
