### PR TITLE
run-server.sh expects third argument not in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To add functionality, I usually start with testing the haskell client with the r
 
 ```bash
 ruby test_server.rb
-./run-server.sh 5555 456
+./run-server.sh 5555 456 .
 ```
 
 The ruby script will fire off various commands to the haskell client. You can check it's output to see that it succeeds (or fails). From there, I just figure out how to make LightTable send the data in the format I need it.


### PR DESCRIPTION
when I tried to run server as in README I've got
light-haskell: user error (Pattern match failure in do expression at haskell/LTHaskellClient.hs:30:5-38)
