### PR TITLE
windows support

### DIFF
--- a/run-server.bat
+++ b/run-server.bat
@@ -1,0 +1,6 @@
+@echo off
+IF NOT EXIST cabal.sandbox.config cabal sandbox init
+
+cabal install --dependencies-only
+
+cabal run %*

--- a/src/lt/plugins/haskell.cljs
+++ b/src/lt/plugins/haskell.cljs
@@ -27,7 +27,10 @@
 (.which shell "cabal")
 
 (def plugin-dir (plugins/find-plugin "Haskell"))
-(def binary-path (files/join plugin-dir "./run-server.sh"))
+;platform hack, windows does not like bash nor the ./ prefix
+(def binary-path (files/join plugin-dir
+                             (if (= platform/platform :windows) "run-server.bat"
+                                                                "./run-server.sh")))
 
 ;; **************************************
 ;; API searching


### PR DESCRIPTION
Windows does not know how to handle bash nor the ./ prefix (isn't this unnecessary anyway?)
This pull request includes a port of the bash script to batch and a platform condition in the plugin.

The first eval prints garbage from ghc starting up, after that all should work fine, not sure if this is a windows specific issue, if so, I could look into that too.
