### PR TITLE
FIX:  Lint/syntax messages does not show on windows.

### DIFF
--- a/src/lt/plugins/haskell.cljs
+++ b/src/lt/plugins/haskell.cljs
@@ -164,7 +164,8 @@
 ;; ***********************************
 
 (defn format-inline-error [error]
-  (let [split-error (.split error ":")
+  (let [error-unified (clj-string/replace error ":\\" "_\\")
+        split-error (.split error-unified ":")
         message-only (->> split-error
                           (drop 3)
                           (clj-string/join ":")


### PR DESCRIPTION
Fix for issue #46 Fixed issue of lint/syntax errors not showing on windows because filename contains drive letter followed by ':' in it.
