### PR TITLE
Build with travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: haskell
 ghc:
   - 7.6
   - 7.8


### PR DESCRIPTION
To make testing new changes easier and at least have _some_ kind of assurance that this still works.

Builds [on GHC 7.6](https://travis-ci.org/heyLu/light-haskell/builds/36974222) as expected, fails on GHC 7.8, which should get fixed by #48.

@psylinse Can you configure travis for this repo and/or give me admin rights so I can do this? Then I could also give other people push rights, if anyone is interested.
